### PR TITLE
Switch from launching Firefox to Firefox Nightly

### DIFF
--- a/packages/devtools-launchpad/bin/firefox-driver.js
+++ b/packages/devtools-launchpad/bin/firefox-driver.js
@@ -85,9 +85,9 @@ function start(_url, _options = {}) {
   options.setProfile(firefoxProfile());
   options.setBinary(firefoxBinary(
     "/Applications/Firefox\ Nightly.app/Contents/MacOS/firefox-bin",
-    "Firefox Nightly\\firefox.exe"
+    "Firefox\ Nightly\\firefox.exe"
   ));
-  
+
   const driver = new webdriver.Builder()
     .forBrowser("firefox")
     .setFirefoxOptions(options)

--- a/packages/devtools-launchpad/bin/firefox-driver.js
+++ b/packages/devtools-launchpad/bin/firefox-driver.js
@@ -49,8 +49,8 @@ function binaryArgs() {
   }
 }
 
-function firefoxBinary() {
-  let binary = new firefox.Binary();
+function firefoxBinary(opt_exeOrChannel) {
+  let binary = new firefox.Binary(opt_exeOrChannel);
 
   binary.addArguments(binaryArgs());
 
@@ -83,8 +83,11 @@ function start(_url, _options = {}) {
   let options = new firefox.Options();
 
   options.setProfile(firefoxProfile());
-  options.setBinary(firefoxBinary());
-
+  options.setBinary(firefoxBinary(
+    "/Applications/Firefox\ Nightly.app/Contents/MacOS/firefox-bin",
+    "Firefox Nightly\\firefox.exe"
+  ));
+  
   const driver = new webdriver.Builder()
     .forBrowser("firefox")
     .setFirefoxOptions(options)

--- a/packages/devtools-launchpad/bin/firefox-driver.js
+++ b/packages/devtools-launchpad/bin/firefox-driver.js
@@ -82,11 +82,14 @@ function start(_url, _options = {}) {
 
   let options = new firefox.Options();
 
+  let nightlyChannel = new firefox.Channel(
+    "/Applications/Firefox Nightly.app/Contents/MacOS/firefox-bin",
+    "Firefox Nightly\\firefox.exe"
+  )
+
   options.setProfile(firefoxProfile());
-  options.setBinary(firefoxBinary(
-    "/Applications/Firefox\ Nightly.app/Contents/MacOS/firefox-bin",
-    "Firefox\ Nightly\\firefox.exe"
-  ));
+  options.setBinary(nightlyChannel);
+  options.args_ = binaryArgs();
 
   const driver = new webdriver.Builder()
     .forBrowser("firefox")

--- a/packages/devtools-launchpad/bin/firefox-driver.js
+++ b/packages/devtools-launchpad/bin/firefox-driver.js
@@ -49,8 +49,8 @@ function binaryArgs() {
   }
 }
 
-function firefoxBinary(opt_exeOrChannel) {
-  let binary = new firefox.Binary(opt_exeOrChannel);
+function firefoxBinary() {
+  let binary = new firefox.Binary();
 
   binary.addArguments(binaryArgs());
 

--- a/packages/devtools-launchpad/src/components/LandingPage.js
+++ b/packages/devtools-launchpad/src/components/LandingPage.js
@@ -100,7 +100,7 @@ class LandingPage extends Component {
     const { name, isUnderConstruction } = sidePanelItems[selectedPane];
     let displayName;
     if (name === "Firefox") {
-      displayName = "Firefox Nightly"
+      displayName = "Firefox Nightly";
     }
 
     const isConnected =

--- a/packages/devtools-launchpad/src/components/LandingPage.js
+++ b/packages/devtools-launchpad/src/components/LandingPage.js
@@ -98,6 +98,10 @@ class LandingPage extends Component {
   renderLaunchOptions() {
     const { selectedPane } = this.state;
     const { name, isUnderConstruction } = sidePanelItems[selectedPane];
+    let displayName;
+    if (name === "Firefox") {
+      displayName = "Firefox Nightly"
+    }
 
     const isConnected =
       name === sidePanelItems.Firefox.name
@@ -115,7 +119,7 @@ class LandingPage extends Component {
 
     const connectedStateText = isNodeSelected
       ? null
-      : `Please open a tab in ${name}`;
+      : `Please open a tab in ${displayName || name}`;
 
     return isConnected
       ? connectedStateText
@@ -123,11 +127,16 @@ class LandingPage extends Component {
   }
 
   renderLaunchButton(browserName, isUnderConstruction) {
+    let browserDisplayName;
+    if (browserName === "Firefox") {
+      browserDisplayName = "Firefox Nightly";
+    }
+
     return dom.div(
       { className: "launch-action-container" },
       dom.button(
         { onClick: () => this.launchBrowser(browserName) },
-        `Launch ${browserName}`
+        `Launch ${browserDisplayName || browserName}`
       ),
       isUnderConstruction ? this.renderExperimentalMessage(browserName) : null
     );

--- a/packages/devtools-launchpad/src/components/Sidebar.js
+++ b/packages/devtools-launchpad/src/components/Sidebar.js
@@ -44,7 +44,7 @@ class Sidebar extends Component {
 
     let displayTitle;
     if (title === "Firefox") {
-      displayTitle = "Firefox Nightly"
+      displayTitle = "Firefox Nightly";
     }
 
     return dom.li(

--- a/packages/devtools-launchpad/src/components/Sidebar.js
+++ b/packages/devtools-launchpad/src/components/Sidebar.js
@@ -41,6 +41,12 @@ class Sidebar extends Component {
 
   renderItem(title) {
     const selected = title == this.props.selectedPane;
+
+    let displayTitle;
+    if (title === "Firefox") {
+      displayTitle = "Firefox Nightly"
+    }
+
     return dom.li(
       { key: title },
       dom.a(
@@ -51,7 +57,7 @@ class Sidebar extends Component {
             this.props.onSideBarItemClick(title);
           }
         },
-        title
+        displayTitle || title
       )
     );
   }


### PR DESCRIPTION
Changed the launchpad so that it launches Firefox to Firefox Nightly. Only updated the bare minimum (display text for launch button and sidebar) so that it's easy to revert when we can use Firefox stable again.

I've checked that it works on Mac, but keeping this as draft as I haven't tested this on Windows yet.
<details><summary><strong>GIF: Launching Firefox Nightly from Launchpad</strong></summary>
<img src="https://user-images.githubusercontent.com/15959269/53105688-94d80280-34ff-11e9-9951-d45460335a25.gif">
</details>
<br>

<details><summary><strong>GIF: Switching between Sidebar tabs</strong></summary>
<img src="https://user-images.githubusercontent.com/15959269/53105956-1334a480-3500-11e9-98ec-9cffb6888a16.gif">
</details>

## Screenshots
<img width="971" alt="screen shot 2019-02-20 at 10 59 27 am" src="https://user-images.githubusercontent.com/15959269/53105193-a967cb00-34fe-11e9-9dbe-83f3efcfcf9b.png">
<img width="1299" alt="screen shot 2019-02-20 at 11 05 18 am" src="https://user-images.githubusercontent.com/15959269/53105638-7ffb6f00-34ff-11e9-97b7-aff11517bff4.png">
