### PR TITLE
Handle the possibility of multiple Webpack configs.

### DIFF
--- a/packages/devtools-launchpad/src/development-server.js
+++ b/packages/devtools-launchpad/src/development-server.js
@@ -195,9 +195,11 @@ function startDevServer(devConfig, webpackConfig, rootDir) {
   app.listen(serverPort, "0.0.0.0", onRequest);
 
   const compiler = webpack(webpackConfig);
+  const firstConfig =
+    Array.isArray(webpackConfig) ? webpackConfig[0] : webpackConfig;
   app.use(
     webpackDevMiddleware(compiler, {
-      publicPath: webpackConfig.output.publicPath,
+      publicPath: firstConfig.output.publicPath,
       noInfo: false,
       stats: "errors-only"
     })


### PR DESCRIPTION
Webpack accepts arrays of configs along with single objects, so the dev server should too.