### PR TITLE
Added skipBreakpoints method to ThreadClient

### DIFF
--- a/packages/devtools-connection/src/debugger/client.js
+++ b/packages/devtools-connection/src/debugger/client.js
@@ -2257,6 +2257,22 @@ ThreadClient.prototype = {
     },
   ),
 
+  /**
+   * Toggle pausing via breakpoints in the server.
+   *
+   * @param skip boolean
+   *        Whether the server should skip pausing via breakpoints
+   */
+  skipBreakpoints: DebuggerClient.requester({
+    type: "skipBreakpoints",
+    skip: args(0),
+  }),
+  
+  /**
+   * Request the frame environment.
+   *
+   * @param frameId string
+   */
   getEnvironment: function(frameId) {
     return this.request({ to: frameId, type: "getEnvironment" });
   },


### PR DESCRIPTION
Fixes [8178](https://github.com/firefox-devtools/debugger/issues/8178).

### Summary of Changes

Added a `skipBreakpoints` method to the ThreadClient prototype.

### Test Plan

1) Copy the modified `client.js` to `debugger/node_modules/devtools/connection/src/debugger`
2) Run the debugger from launchpad
3) Open TodoMVC, set and trigger a breakpoint to check that breakpoints are being paused on
4) Enable skip breakpoints by pressing the "Deactivate Breakpoints" button
5) Check that the breakpoints are no longer paused on
6) Check the console to make sure the error `threadClient.skipBreakpoints is not a function` no longer persists