### PR TITLE
Synchronize context menu changes needed for Bug 1543940

### DIFF
--- a/packages/devtools-contextmenu/menu.js
+++ b/packages/devtools-contextmenu/menu.js
@@ -92,12 +92,12 @@ function showMenu(evt, items) {
     });
 
   if (inToolbox()) {
-    menu.popup(evt.screenX, evt.screenY, { doc: window.parent.document });
+    menu.popup(evt.screenX, evt.screenY, window.parent.document);
     return;
   }
 
   menu.on("open", (_, popup) => onShown(menu, popup));
-  menu.popup(evt.clientX, evt.clientY, { doc: document });
+  menu.popup(evt.clientX, evt.clientY, document);
 }
 
 function createSubMenu(subItems) {

--- a/packages/devtools-modules/src/menu/index.js
+++ b/packages/devtools-modules/src/menu/index.js
@@ -44,6 +44,11 @@ function inToolbox() {
   }
 }
 
+// Copied from m-c DevToolsUtils.
+function getTopWindow(win) {
+  return win.windowRoot ? win.windowRoot.ownerGlobal : win.top;
+}
+
 /**
  * A partial implementation of the Menu API provided by electron:
  * https://github.com/electron/electron/blob/master/docs/api/menu.md.
@@ -95,11 +100,16 @@ Menu.prototype.insert = function (pos, menuItem) {
  *
  * @param {int} screenX
  * @param {int} screenY
- * @param Toolbox toolbox (non standard)
- *        Needed so we in which window to inject XUL
+ * @param {Document} doc
+ *        The document that should own the context menu.
  */
-Menu.prototype.popup = function (screenX, screenY, toolbox) {
-  let doc = toolbox.doc;
+Menu.prototype.popup = function (screenX, screenY, doc) {
+  // The context-menu will be created in the topmost window to preserve keyboard
+  // navigation. See Bug 1543940. Keep a reference on the window owning the menu to hide
+  // the popup on unload.
+  const win = doc.defaultView;
+  doc = getTopWindow(doc.defaultView).document;
+
   let popupset = doc.querySelector("popupset");
   if (!popupset) {
     popupset = doc.createXULElement("popupset");
@@ -122,9 +132,15 @@ Menu.prototype.popup = function (screenX, screenY, toolbox) {
   }
   this._createMenuItems(popup);
 
+  // The context menu will be created in the topmost chrome window. Hide it manually when
+  // the owner document is unloaded.
+  const onWindowUnload = () => popup.hidePopup();
+  win.addEventListener("unload", onWindowUnload);
+
   // Remove the menu from the DOM once it's hidden.
   popup.addEventListener("popuphidden", (e) => {
     if (e.target === popup) {
+      win.removeEventListener("unload", onWindowUnload);
       popup.remove();
       this.emit("close", popup);
     }


### PR DESCRIPTION
Menu API should now take a document argument and there is additional logic to hide the context menu when its parent window is hidden.

The corresponding bugzilla record is https://bugzilla.mozilla.org/show_bug.cgi?id=1543940
It is a mandatory change to run DevTools in frame with type=content (https://bugzilla.mozilla.org/show_bug.cgi?id=1539979) which is required for the overall fission effort.