### PR TITLE
Require Menu and MenuItem with full path to override for mc bundle

### DIFF
--- a/packages/devtools-contextmenu/menu.js
+++ b/packages/devtools-contextmenu/menu.js
@@ -2,7 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const { Menu, MenuItem } = require("devtools-modules");
+const Menu = require("devtools-modules/src/menu");
+const MenuItem = require("devtools-modules/src/menu-item");
 
 function inToolbox() {
   try {

--- a/packages/devtools-modules/index.js
+++ b/packages/devtools-modules/index.js
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const Menu = require("./src/menu");
-const MenuItem = require("./src/menu/menu-item");
 const { PrefsHelper } = require("./src/prefs");
 const KeyShortcuts = require("./src/key-shortcuts");
 const { ZoomKeys } = require("./src/zoom-keys");
@@ -16,8 +14,6 @@ const { getUnicodeHostname, getUnicodeUrlPath, getUnicodeUrl } =
 
 module.exports = {
   KeyShortcuts,
-  Menu,
-  MenuItem,
   PrefsHelper,
   ZoomKeys,
   asyncStorage,


### PR DESCRIPTION
This will allow us to add two mappings to mozilla-central-mappings:
```javascript
    "devtools-modules/src/menu": "devtools/client/framework/menu",
    "devtools-modules/src/menu-item": "devtools/client/framework/menu-item",
```

After this change, the debugger will use the regular menu implementation when running in the toolbox.
There is a lot of cleanup possible between devtools-contextmenu and devtools-modules/src/menu after that, since they are only used when running in content, but I'd leave that for later.