### PR TITLE
Fix inToolbox helpers to detect about:devtools-toolbox URLs

### DIFF
--- a/packages/devtools-contextmenu/menu.js
+++ b/packages/devtools-contextmenu/menu.js
@@ -6,7 +6,7 @@ const { Menu, MenuItem } = require("devtools-modules");
 
 function inToolbox() {
   try {
-    return window.parent.document.documentURI == "about:devtools-toolbox";
+    return window.parent.document.documentURI.startsWith("about:devtools-toolbox");
   } catch (e) {
     // If `window` is not available, it's very likely that we are in the toolbox.
     return true;

--- a/packages/devtools-modules/src/menu/index.js
+++ b/packages/devtools-modules/src/menu/index.js
@@ -37,7 +37,7 @@ function formatKeyShortcut(shortcut) {
 
 function inToolbox() {
   try {
-    return window.parent.document.documentURI == "about:devtools-toolbox";
+    return window.parent.document.documentURI.startsWith("about:devtools-toolbox");
   } catch (e) {
     // If `window` is not available, it's very likely that we are in the toolbox.
     return true;


### PR DESCRIPTION
Sync with https://bugzilla.mozilla.org/show_bug.cgi?id=1552444

"about:devtools-toolbox" is only valid for the default toolbox. We can also have additional parameters to modify the target, the runtime etc...