### PR TITLE
fix typo in path to MenuItem

### DIFF
--- a/packages/devtools-contextmenu/menu.js
+++ b/packages/devtools-contextmenu/menu.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const Menu = require("devtools-modules/src/menu");
-const MenuItem = require("devtools-modules/src/menu-item");
+const MenuItem = require("devtools-modules/src/menu/menu-item");
 
 function inToolbox() {
   try {


### PR DESCRIPTION
Looks like the path was truncated in https://github.com/firefox-devtools/devtools-core/commit/b63607474ea8edbc3d3c2ebfdc78cff4354453db

Noticed on webpack failure while building debugger.html.