### PR TITLE
Add an ObserverService on Services.obs

### DIFF
--- a/packages/devtools-services/index.js
+++ b/packages/devtools-services/index.js
@@ -498,6 +498,33 @@ PrefBranch.prototype = {
   },
 };
 
+class ObserverService {
+  constructor() {
+    this._observers = new Map();
+  }
+
+  addObserver(observer, topic) {
+    const topicObservers = this._observers.get(topic) || [];
+    this._observers.set(topic, topicObservers.concat(observer));
+  }
+
+  removeObserver(observer, topic) {
+    let topicObservers = this._observers.get(topic) || [];
+    topicObservers = topicObservers.filter(obs => obs != observer);
+    if (topicObservers.length === 0) {
+      this._observers.delete(topic);
+    } else {
+      this._observers.set(topic, topicObservers.concat(observer));
+    }
+  }
+
+  notifyObservers(topic, data) {
+    for (const observer of  this._observers.get(topic) || []) {
+      observer(data);
+    }
+  }
+}
+
 window.telemetry = {}
 window.telemetry.histograms = {}
 window.telemetry.scalars = {}
@@ -523,6 +550,12 @@ const Services = {
     }
     return this._prefs;
   },
+
+  
+  /**
+   * An implementation of nsIObserverService.
+   */
+  obs: new ObserverService(),
 
   /**
    * An implementation of Services.appinfo that holds just the


### PR DESCRIPTION
This is needed for the console mocha test on a new patch that adds https://searchfox.org/mozilla-central/rev/17756e2a5c180d980a4b08d99f8cc0c97290ae8d/devtools/shared/flags.js as a dependency (which makes use of `Services.obs`).

I tried to make this approximately correct, but didn't spent too much time in there.