### PR TITLE
Remove references to Scratchpad.

### DIFF
--- a/packages/devtools-modules/src/source-utils.js
+++ b/packages/devtools-modules/src/source-utils.js
@@ -134,14 +134,6 @@ function getSourceNames(source) {
     }
   }
 
- // If Scratchpad URI, like "Scratchpad/1"; no modifications,
- // and short/long are the same.
-  if (isScratchpadScheme(sourceStr)) {
-    let result = { short: sourceStr, long: sourceStr };
-    gSourceNamesStore.set(source, result);
-    return result;
-  }
-
   const parsedUrl = parseURL(sourceStr);
 
   if (!parsedUrl) {
@@ -189,23 +181,6 @@ function getSourceNames(source) {
 function isColonSlashSlash(location, i = 0) {
   return location.charCodeAt(++i) === CHAR_CODE_COLON &&
         location.charCodeAt(++i) === CHAR_CODE_SLASH &&
-        location.charCodeAt(++i) === CHAR_CODE_SLASH;
-}
-
-/**
-* Checks for a Scratchpad URI, like "Scratchpad/1"
-*/
-function isScratchpadScheme(location, i = 0) {
-  return location.charCodeAt(i) === CHAR_CODE_CAP_S &&
-        location.charCodeAt(++i) === CHAR_CODE_C &&
-        location.charCodeAt(++i) === CHAR_CODE_R &&
-        location.charCodeAt(++i) === CHAR_CODE_A &&
-        location.charCodeAt(++i) === CHAR_CODE_T &&
-        location.charCodeAt(++i) === CHAR_CODE_C &&
-        location.charCodeAt(++i) === CHAR_CODE_H &&
-        location.charCodeAt(++i) === CHAR_CODE_P &&
-        location.charCodeAt(++i) === CHAR_CODE_A &&
-        location.charCodeAt(++i) === CHAR_CODE_D &&
         location.charCodeAt(++i) === CHAR_CODE_SLASH;
 }
 
@@ -356,7 +331,6 @@ function getSourceMappedFile(source) {
 module.exports = {
   parseURL,
   getSourceNames,
-  isScratchpadScheme,
   isChromeScheme,
   isContentScheme,
   isWASM,

--- a/packages/devtools-modules/src/tests/source-utils.js
+++ b/packages/devtools-modules/src/tests/source-utils.js
@@ -8,7 +8,6 @@ const {
   isChromeScheme,
   isContentScheme,
   isDataScheme,
-  isScratchpadScheme,
   isWASM,
   parseURL,
 } = require("../source-utils");
@@ -77,12 +76,6 @@ describe("source-utils", () => {
     for (let url of CONTENT_URLS) {
       expect(isDataScheme(url)).toBe(false);
     }
-  });
-
-  it("isScratchpadTheme", () => {
-    expect(isScratchpadScheme("Scratchpad/1")).toBe(true);
-    expect(isScratchpadScheme("Scratchpad/20")).toBe(true);
-    expect(isScratchpadScheme("http://www.mozilla.org")).toBe(false);
   });
 
   it("getSourceMappedFile", () => {


### PR DESCRIPTION
As https://bugzilla.mozilla.org/show_bug.cgi\?id\=1519103 will land
soon, we don't need to deal with Scratchpad anymore.