### PR TITLE
Bump devtools-modules to 1.1.8

### DIFF
--- a/packages/devtools-modules/package.json
+++ b/packages/devtools-modules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devtools-modules",
-  "version": "1.1.6",
+  "version": "1.1.8",
   "description": "DevTools Modules from M-C",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
1.1.7 was published but the version number  change wasn't commited :/ 