### PR TITLE
Bump devtools-contextmenu to 1.0.13.

### DIFF
--- a/packages/devtools-contextmenu/package.json
+++ b/packages/devtools-contextmenu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devtools-contextmenu",
-  "version": "1.0.10",
+  "version": "1.0.13",
   "description": "DevTools Contextmenu",
   "main": "menu.js",
   "scripts": {
@@ -9,6 +9,6 @@
   "author": "Jason Laster",
   "license": "MPL-2.0",
   "dependencies": {
-    "devtools-modules": "~1.1.6"
+    "devtools-modules": "~1.1.8"
   }
 }


### PR DESCRIPTION
We simply require the newest version of devtools-modules.
Jumping to 1.0.13 as there's already a 1.0.12 version published.