### PR TITLE
Bumping launchpad to 0.0.160.

### DIFF
--- a/packages/devtools-launchpad/package.json
+++ b/packages/devtools-launchpad/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devtools-launchpad",
-  "version": "0.0.159",
+  "version": "0.0.160",
   "license": "MPL-2.0",
   "description": "The Launchpad makes it easy to build a developer tool for Firefox, Chrome, and Node.",
   "repository": {
@@ -51,7 +51,7 @@
     "debug": "^3.1.0",
     "devtools-config": "^0.0.16",
     "devtools-connection": "^1.0.7",
-    "devtools-contextmenu": "~1.0.13",
+    "devtools-contextmenu": "~1.0.14",
     "devtools-environment": "^0.0.5",
     "devtools-license-check": "^0.7.0",
     "devtools-mc-assets": "^0.0.7",


### PR DESCRIPTION
We simply require the latest devtools-contextmenu.