### PR TITLE
Add a few more aliases for MPL2 and Apache 2

### DIFF
--- a/packages/devtools-license-check/bin/devtools-license-check
+++ b/packages/devtools-license-check/bin/devtools-license-check
@@ -45,12 +45,14 @@ const VALID_LICENSES = [
 
   "MPL-2.0",
   "MPL 2.0",
+  "MPLv2.0",
 
   "Apache",
   "Apache2",
   "Apache*",
   "Apache-2.0",
   "Apache License, Version 2.0",
+  "Apache-2",
 
   "BSD",
   "BSD-2-Clause",


### PR DESCRIPTION
I found these (invalid) values in some existing packages that we use, some of them transitively, in the profiler server. This would be a bit painful to make them all update...
